### PR TITLE
Handle psycopg_pool fallback and install pool extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask>=3.0,<4
 gunicorn==23.0.0
-psycopg2-binary==2.9.9
+psycopg[binary,pool]==3.2.10
 Authlib>=1.3,<2
 requests>=2.31,<3
 markdown>=3.6,<4


### PR DESCRIPTION
## Summary
- add a psycopg_pool import fallback that opens direct psycopg connections if the pool package is missing
- cache connection info strings for reuse and log when falling back to direct connections
- install the psycopg pool extra alongside the binary distribution so the deployment includes psycopg_pool

## Testing
- python -m compileall main.py profile.py

------
https://chatgpt.com/codex/tasks/task_e_68de34e6c89083319aab15fffde6b39f