### PR TITLE
Add psycopg2 runtime dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 Flask>=3.0,<4
 gunicorn==23.0.0
 psycopg[binary,pool]==3.2.10
+# Provide psycopg2 for libraries that still import the legacy driver during startup
+psycopg2-binary>=2.9,<3
 Authlib>=1.3,<2
 requests>=2.31,<3
 markdown>=3.6,<4


### PR DESCRIPTION
## Summary
- add psycopg2-binary to keep compatibility with environments that still import the legacy driver during startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de457a5cd88331a8473597d139d40f