### PR TITLE
Update Google Calendar scheduling link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -45,7 +45,7 @@
           var target = document.currentScript;
           window.addEventListener('load', function() {
             calendar.schedulingButton.load({
-              url: 'https://calendar.google.com/calendar/appointments/schedules/AcZssZ3lsf1bX7mEb_aET2yTbjn1CSz32XakFN6hJYdP17qgOzsj-0xinow3QsuCt_r-5y_xnMtKohuX?gv=true',
+              url: 'https://calendar.google.com/calendar/appointments/schedules/AcZssZ3BzquEw0WKAWNvyowedp_yheXyxeks5QcJBNUQhtYrAcbC-7tdvi3WYtjrzvgSiDhaiRNczIqN?gv=true',
               color: '#000000',
               label: 'Book an appointment',
               target,


### PR DESCRIPTION
## Summary
- update the Google Calendar scheduling button to use the new appointment link while keeping the existing styling

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df57ad1208833198e0efd3cdfcb218