### PR TITLE
Allow unauthenticated access to public pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -951,6 +951,8 @@ def _is_public_path(path: str) -> bool:
     if path.startswith(STATIC_URL_PATH):
         return True
     public_exact = {
+        "/",
+        _bp("/"),
         "/favicon.ico",
         _bp("/favicon.ico"),
         "/healthz",
@@ -968,7 +970,14 @@ def _is_public_path(path: str) -> bool:
         "/admin/whoami",
         _bp("/admin/whoami"),
     }
-    return path in public_exact
+    if path in public_exact:
+        return True
+
+    public_prefixes = {
+        "/course/",
+        _bp("/course/"),
+    }
+    return any(path.startswith(prefix) for prefix in public_prefixes)
 
 @app.before_request
 def enforce_or_attach_identity():


### PR DESCRIPTION
## Summary
- treat the home page and course detail routes as public so they no longer force a Google login redirect
- keep existing authentication for protected areas while allowing the landing experience to render without OAuth configuration

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e4c6c33c088331898b925281589b96