### PR TITLE
Fix appointment booking link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -46,7 +46,7 @@
           window.addEventListener('load', function() {
             calendar.schedulingButton.load({
               url: 'https://calendar.google.com/calendar/appointments/schedules/AcZssZ3BzquEw0WKAWNvyowedp_yheXyxeks5QcJBNUQhtYrAcbC-7tdvi3WYtjrzvgSiDhaiRNczIqN?gv=true',
-              color: '#000000',
+              color: '#039BE5',
               label: 'Book an appointment',
               target,
             });


### PR DESCRIPTION
## Summary
- update the Google Calendar appointment widget to use the provided configuration

## Testing
- not run (Google OAuth credentials required)


------
https://chatgpt.com/codex/tasks/task_e_68e4c88c9be88331b6d56e62d2e9f083