### PR TITLE
Add password gate for course access

### DIFF
--- a/templates/course_unlock.html
+++ b/templates/course_unlock.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}Course Access{% endblock %}
+
+{% block content %}
+  <section class="login-card">
+    <h1>Course Access</h1>
+    <p>This course is password protected. Enter the access password to continue.</p>
+
+    {% if error %}
+      <div class="alert error" role="alert">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" class="login-form">
+      <input type="hidden" name="next" value="{{ next_url }}">
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" required autofocus>
+      <button type="submit">Unlock course</button>
+    </form>
+  </section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow enabling the password-only sign in flow even when Google OAuth is configured
- add a dedicated /course/unlock flow that stores a session flag after validating the Impact2025 password
- treat lesson routes as publicly reachable once unlocked while leaving other pages protected

## Testing
- `python -m compileall main.py`


------
https://chatgpt.com/codex/tasks/task_e_68e50b7db950833182ceae268885d59a