### PR TITLE
Streamline lesson navigation for large courses

### DIFF
--- a/course.py
+++ b/course.py
@@ -1,6 +1,6 @@
 # course.py
 from typing import Any, Dict, List
-from flask import render_template, redirect, url_for, g, current_app
+from flask import render_template, redirect, url_for, g, current_app, jsonify
 
 def register_course_routes(app, base_path: str, deps: Dict[str, Any]):
     """
@@ -14,6 +14,8 @@ def register_course_routes(app, base_path: str, deps: Dict[str, Any]):
     course_structure = deps.get("course_structure") or (lambda row: ensure_structure((row or {}).get("structure")))
     flatten_lessons = deps["flatten_lessons"]
     sorted_sections_dep = deps.get("sorted_sections")
+    load_course_sidebar_dep = deps.get("load_course_sidebar")
+    load_course_lesson_dep = deps.get("load_course_lesson")
     first_lesson_uid = deps["first_lesson_uid"]
     find_lesson = deps["find_lesson"]
     next_prev_uids = deps["next_prev_uids"]
@@ -76,33 +78,172 @@ def register_course_routes(app, base_path: str, deps: Dict[str, Any]):
             return False
 
     # --- Display-order utilities (stable section/lesson ordering) ---
-    def _sorted_sections_for_viz(structure: Dict[str, Any]) -> List[Dict[str, Any]]:
-        if sorted_sections_dep:
-            result: List[Dict[str, Any]] = []
-            for sec in sorted_sections_dep(structure):
-                lessons = list((sec.get("lessons") or ()))
-                sec_copy = dict(sec)
-                sec_copy["lessons"] = lessons
-                result.append(sec_copy)
-            return result
+    def _sorted_sections_for_viz(structure: Dict[str, Any], row: Dict[str, Any]) -> List[Dict[str, Any]]:
+        def _sanitize_sections(sections_source) -> List[Dict[str, Any]]:
+            cleaned: List[Dict[str, Any]] = []
+            for sec in sections_source or []:
+                if not isinstance(sec, dict):
+                    continue
+                entry = {
+                    "title": sec.get("title"),
+                    "order": sec.get("order"),
+                    "lessons": []
+                }
+                lessons_raw = sec.get("lessons")
+                if isinstance(lessons_raw, (list, tuple)):
+                    lessons_iter = list(lessons_raw)
+                elif lessons_raw:
+                    lessons_iter = [lessons_raw]
+                else:
+                    lessons_iter = []
+                lessons_sorted = sorted(lessons_iter, key=lambda l: (l.get("order") or 0, l.get("title") or ""))
+                for lesson in lessons_sorted:
+                    if not isinstance(lesson, dict):
+                        continue
+                    lesson_entry = {
+                        "lesson_uid": lesson.get("lesson_uid"),
+                        "title": lesson.get("title"),
+                        "order": lesson.get("order"),
+                        "kind": lesson.get("kind"),
+                    }
+                    duration = None
+                    content = lesson.get("content") if isinstance(lesson.get("content"), dict) else None
+                    if isinstance(content, dict):
+                        duration = content.get("duration_sec")
+                    if isinstance(duration, int):
+                        lesson_entry["duration_sec"] = duration
+                    entry["lessons"].append(lesson_entry)
+                cleaned.append(entry)
+            return cleaned
 
-        secs_raw = (structure.get("sections") or [])
-        secs_sorted = sorted(secs_raw, key=lambda s: (s.get("order") or 0, s.get("title") or ""))
-        out = []
-        for s in secs_sorted:
-            s2 = dict(s)
-            lessons = s.get("lessons") or []
-            lessons_sorted = sorted(lessons, key=lambda l: (l.get("order") or 0, l.get("title") or ""))
-            s2["lessons"] = lessons_sorted
-            out.append(s2)
-        return out
+        sections_candidate = None
+        if load_course_sidebar_dep:
+            try:
+                sections_candidate = load_course_sidebar_dep(structure)
+            except TypeError:
+                sections_candidate = load_course_sidebar_dep(row.get("structure"), course_title=row.get("title"))
+            except Exception as e:
+                print("[learn] load_course_sidebar failed:", e)
+                sections_candidate = None
+            if isinstance(sections_candidate, list):
+                return _sanitize_sections(sections_candidate)
+
+        if sorted_sections_dep:
+            try:
+                sections_candidate = sorted_sections_dep(structure)
+            except Exception as e:
+                print("[learn] sorted_sections failed:", e)
+                sections_candidate = None
+            if sections_candidate is not None:
+                return _sanitize_sections(sections_candidate)
+
+        secs_raw = structure.get("sections")
+        if isinstance(secs_raw, (list, tuple)):
+            sections_candidate = sorted(secs_raw, key=lambda s: (s.get("order") or 0, s.get("title") or ""))
+        elif secs_raw:
+            sections_candidate = [secs_raw]
+        else:
+            sections_candidate = []
+        return _sanitize_sections(sections_candidate)
 
     def _find_lesson_in_sorted_sections(sections_sorted: List[Dict[str, Any]], lesson_uid: str):
         for si, sec in enumerate(sections_sorted):
             for li, l in enumerate(sec.get("lessons") or []):
                 if str(l.get("lesson_uid")) == str(lesson_uid):
-                    return si, li, l
-        return None, None, None
+                    return si, li
+        return None, None
+
+    def _lesson_for_uid(structure: Dict[str, Any], lesson_uid: str, row: Dict[str, Any]):
+        lesson = None
+        if load_course_lesson_dep:
+            try:
+                lesson = load_course_lesson_dep(structure, lesson_uid)
+            except TypeError:
+                lesson = load_course_lesson_dep(row.get("structure"), lesson_uid, course_title=row.get("title"))
+            except Exception as e:
+                print("[learn] load_course_lesson failed:", e)
+                lesson = None
+        if lesson is None and find_lesson:
+            try:
+                si, li = find_lesson(structure, lesson_uid)
+            except Exception as e:
+                print("[learn] find_lesson failed:", e)
+                si = li = None
+            if si is not None and li is not None:
+                try:
+                    sections_raw = structure.get("sections") or []
+                    section = sections_raw[si] if isinstance(sections_raw, list) else None
+                    lessons = section.get("lessons") if isinstance(section, dict) else None
+                    if isinstance(lessons, list) and 0 <= li < len(lessons):
+                        lesson = lessons[li]
+                except Exception as e:
+                    print("[learn] lesson lookup failed:", e)
+                    lesson = None
+        return lesson
+
+    def _lesson_context(course_id: int, row: Dict[str, Any], lesson_uid: str, *, include_sections: bool):
+        structure = course_structure(row)
+        idx_map = lesson_index_map(structure)
+        current_idx = idx_map.get(str(lesson_uid))
+        if current_idx is None:
+            return {"redirect": first_lesson_uid(structure)}
+
+        sections_viz = _sorted_sections_for_viz(structure, row) if include_sections else None
+        seen = seen_lessons(g.user_id, course_id) if getattr(g, "user_id", None) else set()
+        frontier_before = frontier_from_seen(structure, seen)
+        total = num_lessons(structure)
+        allowed_next = total - 1 if total else 0
+
+        try:
+            if getattr(g, "user_id", None):
+                log_view_once(g.user_id, course_id, str(lesson_uid), window_seconds=120)
+                seen_after = set(seen)
+                seen_after.add(str(lesson_uid))
+                frontier_after = frontier_from_seen(structure, seen_after)
+                if frontier_after > frontier_before:
+                    log_activity(
+                        g.user_id,
+                        course_id,
+                        str(lesson_uid),
+                        "unlock",
+                        payload={"kind": "unlock", "from": frontier_before, "to": frontier_after},
+                    )
+        except Exception as e:
+            print("[activity] logging failed:", e)
+
+        prev_uid, next_uid = next_prev_uids(structure, lesson_uid)
+        lesson = _lesson_for_uid(structure, lesson_uid, row)
+        if lesson is None:
+            return {"redirect": first_lesson_uid(structure)}
+
+        section_index = None
+        if include_sections and sections_viz is not None:
+            si_sorted, _ = _find_lesson_in_sorted_sections(sections_viz, lesson_uid)
+            if si_sorted is None:
+                allowed_uid = uid_by_index(structure, allowed_next) or first_lesson_uid(structure)
+                return {"redirect": allowed_uid}
+            section_index = si_sorted
+
+        course_meta = {
+            "id": row["id"],
+            "title": row.get("title"),
+            "slug": slugify(row.get("title") or f"course-{course_id}"),
+            "duration_total": format_duration(total_course_duration(structure)),
+            "lessons_count": len(flatten_lessons(structure)),
+        }
+
+        return {
+            "structure": structure,
+            "sections": sections_viz,
+            "lesson": lesson,
+            "prev_uid": prev_uid,
+            "next_uid": next_uid,
+            "allowed_next": allowed_next,
+            "frontier_before": frontier_before,
+            "idx_map": idx_map,
+            "section_index": section_index,
+            "course_meta": course_meta,
+        }
 
     # ----- Routes -----
     def learn_redirect_to_first(course_id: int):
@@ -135,51 +276,20 @@ def register_course_routes(app, base_path: str, deps: Dict[str, Any]):
         if not row:
             from flask import abort
             abort(404)
-        st = course_structure(row)
-        sections_viz = _sorted_sections_for_viz(st)
-        idx_map = lesson_index_map(st)
+        ctx = _lesson_context(course_id, row, lesson_uid, include_sections=True)
+        redirect_uid = ctx.get("redirect")
+        if redirect_uid:
+            return redirect(url_for("learn_lesson", course_id=course_id, lesson_uid=redirect_uid))
 
-        # Validate lesson exists in structure
-        cur_idx = idx_map.get(str(lesson_uid))
-        if cur_idx is None:
-            fallback_uid = first_lesson_uid(st)
-            return redirect(url_for("learn_lesson", course_id=course_id, lesson_uid=fallback_uid))
-
-        # With gating removed, expose all lessons regardless of prior progress.
-        seen = seen_lessons(g.user_id, course_id) if getattr(g, "user_id", None) else set()
-        frontier_before = frontier_from_seen(st, seen)
-        total = num_lessons(st)
-        allowed_next = total - 1 if total else 0
-
-        # Log view (debounced) + unlock on advance
-        try:
-            if getattr(g, "user_id", None):
-                log_view_once(g.user_id, course_id, str(lesson_uid), window_seconds=120)
-                seen_after = set(seen); seen_after.add(str(lesson_uid))
-                frontier_after = frontier_from_seen(st, seen_after)
-                if frontier_after > frontier_before:
-                    log_activity(
-                        g.user_id, course_id, str(lesson_uid), "unlock",
-                        payload={"kind": "unlock", "from": frontier_before, "to": frontier_after}
-                    )
-        except Exception as e:
-            print("[activity] logging failed:", e)
-
-        si_sorted, li_sorted, lesson_viz = _find_lesson_in_sorted_sections(sections_viz, lesson_uid)
-        if si_sorted is None:
-            allowed_uid = uid_by_index(st, allowed_next) or first_lesson_uid(st)
-            return redirect(url_for("learn_lesson", course_id=course_id, lesson_uid=allowed_uid))
-
-        lesson = lesson_viz
-        prev_uid, next_uid = next_prev_uids(st, lesson_uid)
-
-        course_meta = {
-            "id": row["id"],
-            "title": row.get("title"),
-            "slug": slugify(row.get("title") or f"course-{course_id}"),
-            "duration_total": format_duration(total_course_duration(st)),
-            "lessons_count": len(flatten_lessons(st)),
-        }
+        sections_viz = ctx.get("sections") or []
+        lesson = ctx.get("lesson")
+        prev_uid = ctx.get("prev_uid")
+        next_uid = ctx.get("next_uid")
+        allowed_next = ctx.get("allowed_next", 0)
+        idx_map = ctx.get("idx_map") or {}
+        course_meta = ctx.get("course_meta") or {}
+        global_frontier_index = ctx.get("frontier_before", 0)
+        current_section_index = ctx.get("section_index")
 
         learner_name = None
         reg = None
@@ -193,15 +303,13 @@ def register_course_routes(app, base_path: str, deps: Dict[str, Any]):
         except Exception as e:
             print("[learn] registration name lookup failed:", e)
 
-        global_frontier_index = frontier_before
-
         exam_statuses = _exam_statuses_for_course(course_id)
 
         return render_template(
             "learn.html",
             course=course_meta,
             sections=sections_viz,                 # sorted for display and week mapping
-            current_section_index=si_sorted,       # sorted index → Week N = +1
+            current_section_index=current_section_index,       # sorted index → Week N = +1
             current_lesson_uid=str(lesson_uid),
             lesson=lesson,
             prev_uid=prev_uid,
@@ -214,9 +322,58 @@ def register_course_routes(app, base_path: str, deps: Dict[str, Any]):
             exam_statuses=exam_statuses,
         )
 
+    def learn_lesson_data(course_id: int, lesson_uid: str):
+        row = fetch_one("SELECT id, title, structure FROM courses WHERE id = %s;", (course_id,))
+        if not row:
+            from flask import abort
+            abort(404)
+
+        ctx = _lesson_context(course_id, row, lesson_uid, include_sections=False)
+        redirect_uid = ctx.get("redirect")
+        if redirect_uid:
+            redirect_url = url_for("learn_lesson", course_id=course_id, lesson_uid=redirect_uid)
+            return jsonify({"ok": False, "redirect_url": redirect_url}), 404
+
+        lesson = ctx.get("lesson")
+        if lesson is None:
+            return jsonify({"ok": False}), 404
+
+        prev_uid = ctx.get("prev_uid")
+        next_uid = ctx.get("next_uid")
+        prev_url = url_for("learn_lesson", course_id=course_id, lesson_uid=prev_uid) if prev_uid else None
+        next_url = url_for("learn_lesson", course_id=course_id, lesson_uid=next_uid) if next_uid else None
+
+        payload = {
+            "ok": True,
+            "lesson_uid": str(lesson_uid),
+            "lesson_title": lesson.get("title") or "Lesson",
+            "lesson_html": render_template("partials/lesson_body.html", lesson=lesson),
+            "prev_uid": prev_uid,
+            "next_uid": next_uid,
+            "prev_url": prev_url,
+            "next_url": next_url,
+            "course_home_url": url_for("course_detail", course_id=course_id),
+            "page_url": url_for("learn_lesson", course_id=course_id, lesson_uid=lesson_uid),
+            "prefetch_urls": [u for u in (prev_url, next_url) if u],
+        }
+
+        return jsonify(payload)
+
     # Register with same endpoint names as before
     app.add_url_rule("/learn/<int:course_id>", view_func=learn_redirect_to_first, methods=["GET"], endpoint="learn_redirect_to_first")
     app.add_url_rule("/learn/<int:course_id>/<lesson_uid>", view_func=learn_lesson, methods=["GET"], endpoint="learn_lesson")
+    app.add_url_rule(
+        "/learn/<int:course_id>/<lesson_uid>/data",
+        view_func=learn_lesson_data,
+        methods=["GET"],
+        endpoint="learn_lesson_data",
+    )
 
     _alias("/learn/<int:course_id>", learn_redirect_to_first, ["GET"])
     _alias("/learn/<int:course_id>/<lesson_uid>", learn_lesson, ["GET"])
+    _alias(
+        "/learn/<int:course_id>/<lesson_uid>/data",
+        learn_lesson_data,
+        ["GET"],
+        endpoint_suffix="alias_data",
+    )

--- a/main.py
+++ b/main.py
@@ -471,7 +471,7 @@ def _lesson_sort_key(lesson: Any) -> Tuple[Any, Any]:
 
 def _structure_cache_data(structure: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(structure, dict):
-        return {"sections": tuple(), "flat": tuple(), "uids": tuple()}
+        return {"sections": tuple(), "flat": tuple(), "uids": tuple(), "sidebar": tuple(), "lesson_lookup": {}}
 
     sections_raw = structure.get("sections")
     if isinstance(sections_raw, (list, tuple)):
@@ -484,6 +484,8 @@ def _structure_cache_data(structure: Dict[str, Any]) -> Dict[str, Any]:
     sections_sorted: List[Dict[str, Any]] = []
     flat: List[Tuple[dict, dict]] = []
     uids: List[str] = []
+    sidebar_sections: List[Dict[str, Any]] = []
+    lesson_lookup: Dict[str, Dict[str, Any]] = {}
 
     for section in sorted(sections_iter, key=_section_sort_key):
         if isinstance(section, dict):
@@ -501,18 +503,43 @@ def _structure_cache_data(structure: Dict[str, Any]) -> Dict[str, Any]:
             section_copy = {"value": section, "lessons": tuple()}
         section_copy["lessons"] = tuple(lessons_sorted)
         sections_sorted.append(section_copy)
+
+        sidebar_lessons: List[Dict[str, Any]] = []
         for lesson in lessons_sorted:
             if not isinstance(lesson, dict):
                 continue
             flat.append((section_copy, lesson))
             uid = lesson.get("lesson_uid")
             if uid is not None:
-                uids.append(str(uid))
+                uid_str = str(uid)
+                uids.append(uid_str)
+                lesson_lookup[uid_str] = lesson
+
+            sidebar_entry = {
+                "lesson_uid": lesson.get("lesson_uid"),
+                "title": lesson.get("title"),
+                "order": lesson.get("order"),
+                "kind": lesson.get("kind"),
+            }
+            content = lesson.get("content") if isinstance(lesson.get("content"), dict) else None
+            if isinstance(content, dict):
+                dur = content.get("duration_sec")
+                if isinstance(dur, int):
+                    sidebar_entry["duration_sec"] = dur
+            sidebar_lessons.append(sidebar_entry)
+
+        sidebar_sections.append({
+            "title": section_copy.get("title"),
+            "order": section_copy.get("order"),
+            "lessons": tuple(sidebar_lessons),
+        })
 
     return {
         "sections": tuple(sections_sorted),
         "flat": tuple(flat),
         "uids": tuple(uids),
+        "sidebar": tuple(sidebar_sections),
+        "lesson_lookup": lesson_lookup,
     }
 
 def _structure_cache(structure: Dict[str, Any]) -> Dict[str, Any]:
@@ -544,6 +571,30 @@ def flatten_lessons(structure: Dict[str, Any]):
 
 def _lesson_uids(structure: Dict[str, Any]) -> Tuple[str, ...]:
     return _structure_cache(structure)["uids"]
+
+def sidebar_sections(structure: Dict[str, Any]) -> List[Dict[str, Any]]:
+    cached = _structure_cache(structure)
+    sidebar = cached.get("sidebar") or tuple()
+    result: List[Dict[str, Any]] = []
+    for section in sidebar:
+        if not isinstance(section, dict):
+            continue
+        sec_copy = {
+            "title": section.get("title"),
+            "order": section.get("order"),
+            "lessons": []
+        }
+        lessons_iter = section.get("lessons") or tuple()
+        for lesson in lessons_iter:
+            if isinstance(lesson, dict):
+                sec_copy["lessons"].append(dict(lesson))
+        result.append(sec_copy)
+    return result
+
+def lesson_from_structure(structure: Dict[str, Any], lesson_uid: str):
+    cached = _structure_cache(structure)
+    lookup = cached.get("lesson_lookup") or {}
+    return lookup.get(str(lesson_uid))
 
 def _frontier_from_seen(structure: Dict[str, Any], seen: Set[str]) -> int:
     frontier = -1
@@ -654,6 +705,31 @@ def course_structure_from_row(row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         row.get("structure"),
         course_title=row.get("title"),
     )
+
+
+def _coerce_structure(structure_raw: Any, course_title: Optional[str] = None) -> Dict[str, Any]:
+    if isinstance(structure_raw, dict):
+        return ensure_structure(structure_raw)
+    return ensure_structure(load_course_structure(structure_raw, course_title=course_title))
+
+
+def load_course_sidebar(
+    structure_raw: Any,
+    *,
+    course_title: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    structure = _coerce_structure(structure_raw, course_title)
+    return sidebar_sections(structure)
+
+
+def load_course_lesson(
+    structure_raw: Any,
+    lesson_uid: str,
+    *,
+    course_title: Optional[str] = None,
+):
+    structure = _coerce_structure(structure_raw, course_title)
+    return lesson_from_structure(structure, lesson_uid)
 
 def first_lesson_uid(structure: Dict[str, Any]) -> Optional[str]:
     flat = flatten_lessons(structure)
@@ -1203,6 +1279,8 @@ _course_deps = {
     "ensure_structure": ensure_structure,
     "course_structure": course_structure_from_row,
     "load_course_structure": load_course_structure,
+    "load_course_sidebar": load_course_sidebar,
+    "load_course_lesson": load_course_lesson,
     "flatten_lessons": flatten_lessons,
     "sorted_sections": sorted_sections,
     "first_lesson_uid": first_lesson_uid,
@@ -1248,6 +1326,8 @@ learn_bp = create_learn_blueprint(BASE_PATH, {
     "ensure_structure": ensure_structure,
     "course_structure": course_structure_from_row,
     "load_course_structure": load_course_structure,
+    "load_course_sidebar": load_course_sidebar,
+    "load_course_lesson": load_course_lesson,
     "flatten_lessons": flatten_lessons,
     "sorted_sections": sorted_sections,
     "first_lesson_uid": first_lesson_uid, "find_lesson": find_lesson,

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -73,6 +73,8 @@
                 {% set idx = lesson_index_by_uid[uid] if lesson_index_by_uid and (uid in lesson_index_by_uid) else None %}
                 <li>
                   <a class="lesson-link {% if is_current %}current{% endif %}"
+                     data-kind="lesson"
+                     data-lesson-uid="{{ uid }}"
                      href="{{ bp('/learn/' ~ course.id ~ '/' ~ uid) }}">{{ l.title or 'Lesson' }}</a>
                 </li>
               {% endfor %}
@@ -99,6 +101,7 @@
               {# Week Exam (preloaded status) #}
               <li>
                 <a class="lesson-link exam-link"
+                   data-kind="exam"
                    href="{{ url_for('exam.exam_start_or_resume', course_id=course.id, week_index=week_n) }}"
                    data-week="{{ week_n }}">
                    📝 Week {{ week_n }} Exam
@@ -109,6 +112,7 @@
               {# Conversation – independent entry #}
               <li class="conversation-item" data-week="{{ week_n }}" {% if not (conversation_allowed_for_week or is_conv_current) %}hidden{% endif %}>
                 <a class="lesson-link {% if is_conv_current %}current{% endif %}"
+                   data-kind="conversation"
                    href="{{ url_for('learn.conversation_page', course_id=course.id, week_index=week_n) }}">
                    💬 Conversation
                 </a>
@@ -126,72 +130,13 @@
       {% if conversation_mode %}
         <h1>Conversation</h1>
       {% else %}
-        <h1>{{ lesson.title or 'Lesson' }}</h1>
+        <h1 id="lesson-title">{{ lesson.title or 'Lesson' }}</h1>
       {% endif %}
     </div>
 
-    <div class="learn-body">
+    <div class="learn-body" id="lesson-body">
       {% if not conversation_mode %}
-        {# ------------------------ NORMAL LESSON BODY ------------------------ #}
-        {% set c = lesson.content or {} %}
-
-        {% if (lesson.kind or '') == 'video' %}
-          {% if c.url %}
-            <div class="video-frame"><video controls preload="metadata" src="{{ c.url }}"></video></div>
-          {% else %}
-            <div class="alert">No video URL provided.</div>
-          {% endif %}
-          {% if c.notes_md %}<div class="prose">{{ c.notes_md | rich }}</div>{% endif %}
-
-        {% elif (lesson.kind or '') == 'article' %}
-          {% if c.body_md %}
-            <div class="prose">{{ c.body_md | rich }}</div>
-          {% else %}
-            <p class="muted">No article content.</p>
-          {% endif %}
-
-        {% elif (lesson.kind or '') == 'quiz' %}
-          {% set qs = c.questions or [] %}
-          {% if qs|length == 0 %}
-            <p class="muted">No quiz questions yet.</p>
-          {% else %}
-            <div class="card quiz-wrap">
-              <h3 style="margin-top:0">Quiz</h3>
-              {% for q in qs %}
-                {% set q_index = loop.index0 %}
-                {% set qtype = q.qtype or 'single_choice' %}
-                <fieldset>
-                  <legend>Q{{ loop.index }}.</legend>
-                  <div class="prose" style="margin-bottom:6px">{{ q.prompt_md | rich }}</div>
-                  {% if (qtype == 'single_choice') or (qtype == 'multiple_choice') %}
-                    {% set input_type = 'radio' if qtype == 'single_choice' else 'checkbox' %}
-                    {% set group_name = 'q' ~ q_index %}
-                    {% for opt in q.options or [] %}
-                      {% set opt_id = 'q' ~ q_index ~ '_opt' ~ loop.index0 %}
-                      <label class="choice" for="{{ opt_id }}">
-                        <input id="{{ opt_id }}" type="{{ input_type }}" name="{{ group_name }}{% if input_type == 'checkbox' %}[]{% endif %}" />
-                        <span class="opt-index">{{ 'ABCD'[:4][loop.index0] if loop.index0 < 4 else loop.index }}</span>
-                        <span class="prose" style="display:inline-block">{{ opt.text_md | rich }}</span>
-                      </label>
-                    {% endfor %}
-                  {% else %}
-                    <textarea rows="4" style="width:100%" placeholder="Type your answer…"></textarea>
-                  {% endif %}
-                </fieldset>
-              {% endfor %}
-              <div class="quiz-note">* This quiz is for practice. Client-side scoring can be added later.</div>
-            </div>
-          {% endif %}
-
-        {% elif (lesson.kind or '') == 'assignment' %}
-          <div class="prose">{{ (c.instructions_md or '<p>Assignment details TBA</p>') | rich }}</div>
-          {% if c.resource_url %}
-            <p><a class="btn ghost" href="{{ c.resource_url }}" target="_blank" rel="noopener">Open Resource</a></p>
-          {% endif %}
-
-        {% else %}
-          <pre><code>{{ (lesson.content or {}) | tojson(indent=2) }}</code></pre>
-        {% endif %}
+        {% include "partials/lesson_body.html" %}
 
       {% else %}
         {# ---------------------- CONVERSATION PAGE BODY ---------------------- #}
@@ -243,14 +188,14 @@
         </div>
       {% else %}
         {% if prev_uid %}
-          <a class="btn ghost" rel="prev" href="{{ bp('/learn/' ~ course.id ~ '/' ~ prev_uid) }}">← Previous</a>
+          <a class="btn ghost" rel="prev" data-role="prev-slot" data-kind="lesson" data-lesson-uid="{{ prev_uid }}" href="{{ bp('/learn/' ~ course.id ~ '/' ~ prev_uid) }}">← Previous</a>
         {% else %}
-          <span></span>
+          <span data-role="prev-slot"></span>
         {% endif %}
         {% if next_uid %}
-          <a class="btn" rel="next" id="next-btn" href="{{ bp('/learn/' ~ course.id ~ '/' ~ next_uid) }}">Next →</a>
+          <a class="btn" rel="next" id="next-btn" data-role="next-slot" data-kind="lesson" data-lesson-uid="{{ next_uid }}" href="{{ bp('/learn/' ~ course.id ~ '/' ~ next_uid) }}">Next →</a>
         {% else %}
-          <a class="btn ghost" href="{{ bp('/course/' ~ course.id ~ '-' ~ course.slug) }}">Back to course</a>
+          <a class="btn ghost" data-role="next-slot" href="{{ bp('/course/' ~ course.id ~ '-' ~ course.slug) }}">Back to course</a>
         {% endif %}
       {% endif %}
     </div>
@@ -300,20 +245,272 @@
       });
     }
 
-    // Keyboard navigation for lesson pages only.
     {% if not conversation_mode %}
-    document.addEventListener('keydown', function(e){
-      if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable)) return;
-      if (e.key === 'ArrowRight') {
-        var n = document.querySelector('a#next-btn[href]');
-        if (n) { window.location.href = n.getAttribute('href'); }
-      } else if (e.key === 'ArrowLeft') {
-        var p = document.querySelector('.learn-nav a[rel="prev"][href]');
-        if (p) { window.location.href = p.getAttribute('href'); }
+    (function(){
+      var courseId = {{ course.id|tojson }};
+      var courseTitle = {{ course.title|tojson }};
+      var initialLessonUid = {{ current_lesson_uid|tojson }};
+      var initialLessonTitle = {{ (lesson.title or 'Lesson')|tojson }};
+      var initialPrevHref = {{ prev_uid and bp('/learn/' ~ course.id ~ '/' ~ prev_uid)|tojson or 'null' }};
+      var initialNextHref = {{ next_uid and bp('/learn/' ~ course.id ~ '/' ~ next_uid)|tojson or 'null' }};
+      var courseHomeHref = {{ bp('/course/' ~ course.id ~ '-' ~ course.slug)|tojson }};
+      var progressKey = "progress_course_" + courseId;
+      var lessonBodyEl = document.getElementById('lesson-body');
+      var lessonTitleEl = document.getElementById('lesson-title');
+      var sidebarEl = document.querySelector('.learn-sidebar');
+      var navEl = document.querySelector('.learn-nav');
+      if (!lessonBodyEl || !lessonTitleEl || !sidebarEl || !navEl) {
+        prefetchNavTargets();
+        return;
       }
-    });
 
-    prefetchNavTargets();
+      history.replaceState({ lessonUid: initialLessonUid }, '', window.location.href);
+      document.title = 'Learn · ' + initialLessonTitle + ' · ' + courseTitle;
+
+      var prevSlot = navEl.querySelector('[data-role="prev-slot"]');
+      var nextSlot = navEl.querySelector('[data-role="next-slot"]');
+      var activeRequestId = 0;
+
+      function escapeSelector(value){
+        if (window.CSS && typeof window.CSS.escape === 'function') {
+          return CSS.escape(value);
+        }
+        return String(value).replace(/["\\]/g, '\\$&');
+      }
+
+      function buildDataUrl(href){
+        if (!href) return null;
+        try {
+          var url = new URL(href, window.location.origin);
+          var path = url.pathname || '';
+          if (path.length > 1 && path.endsWith('/')) {
+            path = path.slice(0, -1);
+          }
+          url.pathname = path + '/data';
+          return url.toString();
+        } catch (err) {
+          if (href.endsWith('/')) href = href.slice(0, -1);
+          return href + '/data';
+        }
+      }
+
+      function setActiveLesson(lessonUid){
+        sidebarEl.querySelectorAll('a.lesson-link.current').forEach(function(link){
+          link.classList.remove('current');
+        });
+        if (!lessonUid) return;
+        try {
+          var target = sidebarEl.querySelector('a.lesson-link[data-lesson-uid="' + escapeSelector(lessonUid) + '"]');
+          if (target) {
+            target.classList.add('current');
+          }
+        } catch (err) {
+          // ignore selector errors
+        }
+      }
+
+      function updateNav(prevUrl, prevUid, nextUrl, nextUid){
+        if (prevSlot) {
+          var newPrev;
+          if (prevUrl && prevUid) {
+            newPrev = document.createElement('a');
+            newPrev.className = 'btn ghost';
+            newPrev.setAttribute('rel', 'prev');
+            newPrev.setAttribute('data-role', 'prev-slot');
+            newPrev.setAttribute('data-kind', 'lesson');
+            newPrev.setAttribute('data-lesson-uid', prevUid);
+            newPrev.href = prevUrl;
+            newPrev.textContent = '← Previous';
+          } else {
+            newPrev = document.createElement('span');
+            newPrev.setAttribute('data-role', 'prev-slot');
+          }
+          prevSlot.replaceWith(newPrev);
+          prevSlot = newPrev;
+        }
+
+        if (nextSlot) {
+          var newNext;
+          if (nextUrl && nextUid) {
+            newNext = document.createElement('a');
+            newNext.className = 'btn';
+            newNext.id = 'next-btn';
+            newNext.setAttribute('rel', 'next');
+            newNext.setAttribute('data-role', 'next-slot');
+            newNext.setAttribute('data-kind', 'lesson');
+            newNext.setAttribute('data-lesson-uid', nextUid);
+            newNext.href = nextUrl;
+            newNext.textContent = 'Next →';
+          } else {
+            newNext = document.createElement('a');
+            newNext.className = 'btn ghost';
+            newNext.setAttribute('data-role', 'next-slot');
+            newNext.href = courseHomeHref;
+            newNext.textContent = 'Back to course';
+          }
+          nextSlot.replaceWith(newNext);
+          nextSlot = newNext;
+        }
+
+        prefetchNavTargets();
+      }
+
+      function prefetchForPayload(payload){
+        var extras = [];
+        if (payload && Array.isArray(payload.prefetch_urls)) {
+          extras = extras.concat(payload.prefetch_urls.filter(Boolean));
+        }
+        if (payload && payload.prev_url) {
+          var prevData = buildDataUrl(payload.prev_url);
+          if (prevData) extras.push(prevData);
+        }
+        if (payload && payload.next_url) {
+          var nextData = buildDataUrl(payload.next_url);
+          if (nextData) extras.push(nextData);
+        }
+        if (extras.length) {
+          prefetchNavTargets({ extraHrefs: extras });
+        }
+      }
+
+      function beginLoading(){
+        if (lessonBodyEl) {
+          lessonBodyEl.classList.add('is-loading');
+          lessonBodyEl.setAttribute('aria-busy', 'true');
+        }
+      }
+
+      function finalizeLoading(){
+        if (lessonBodyEl) {
+          lessonBodyEl.classList.remove('is-loading');
+          lessonBodyEl.removeAttribute('aria-busy');
+        }
+      }
+
+      function renderLesson(payload){
+        if (lessonTitleEl) {
+          lessonTitleEl.textContent = payload.lesson_title || 'Lesson';
+        }
+        if (lessonBodyEl) {
+          lessonBodyEl.innerHTML = payload.lesson_html || '';
+        }
+        setActiveLesson(payload.lesson_uid);
+        updateNav(payload.prev_url, payload.prev_uid, payload.next_url, payload.next_uid);
+        if (payload.lesson_uid) {
+          try { localStorage.setItem(progressKey, payload.lesson_uid); } catch (err) {}
+        }
+        document.title = 'Learn · ' + (payload.lesson_title || 'Lesson') + ' · ' + courseTitle;
+        prefetchForPayload(payload);
+      }
+
+      function shouldHandle(event, link){
+        if (!link) return false;
+        if (link.target && link.target.toLowerCase() === '_blank') return false;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false;
+        return true;
+      }
+
+      function loadLesson(href, opts){
+        opts = opts || {};
+        if (!href) return;
+        var dataUrl = buildDataUrl(href);
+        if (!dataUrl) {
+          window.location.href = href;
+          return;
+        }
+        var requestId = ++activeRequestId;
+        beginLoading();
+        fetch(dataUrl, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+          .then(function(res){
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            return res.json();
+          })
+          .then(function(payload){
+            if (requestId !== activeRequestId) return;
+            if (!payload || !payload.ok) {
+              if (payload && payload.redirect_url) {
+                window.location.href = payload.redirect_url;
+                return;
+              }
+              throw new Error('bad-payload');
+            }
+            renderLesson(payload);
+            if (opts.replaceState) {
+              history.replaceState({ lessonUid: payload.lesson_uid }, '', payload.page_url || href);
+            } else if (opts.pushState !== false) {
+              history.pushState({ lessonUid: payload.lesson_uid }, '', payload.page_url || href);
+            }
+          })
+          .catch(function(err){
+            if (requestId === activeRequestId) {
+              console.error('lesson fetch failed', err);
+              window.location.href = href;
+            }
+          })
+          .finally(function(){
+            if (requestId === activeRequestId) {
+              finalizeLoading();
+            }
+          });
+      }
+
+      sidebarEl.addEventListener('click', function(e){
+        var link = e.target.closest('a.lesson-link[data-kind="lesson"]');
+        if (!shouldHandle(e, link)) return;
+        e.preventDefault();
+        loadLesson(link.getAttribute('href'));
+      });
+
+      navEl.addEventListener('click', function(e){
+        var link = e.target.closest('[data-role="prev-slot"],[data-role="next-slot"]');
+        if (!link || link.getAttribute('data-kind') !== 'lesson') return;
+        if (!shouldHandle(e, link)) return;
+        e.preventDefault();
+        loadLesson(link.getAttribute('href'));
+      });
+
+      document.addEventListener('keydown', function(e){
+        if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable)) return;
+        if (e.key === 'ArrowRight') {
+          var nextLink = navEl.querySelector('[data-role="next-slot"][data-kind="lesson"]');
+          if (nextLink) {
+            e.preventDefault();
+            loadLesson(nextLink.getAttribute('href'));
+          }
+        } else if (e.key === 'ArrowLeft') {
+          var prevLink = navEl.querySelector('[data-role="prev-slot"][data-kind="lesson"]');
+          if (prevLink) {
+            e.preventDefault();
+            loadLesson(prevLink.getAttribute('href'));
+          }
+        }
+      });
+
+      window.addEventListener('popstate', function(event){
+        if (!event.state || !event.state.lessonUid) {
+          window.location.href = window.location.href;
+          return;
+        }
+        loadLesson(window.location.href, { pushState: false, replaceState: true });
+      });
+
+      var initialExtras = [];
+      if (initialPrevHref) {
+        initialExtras.push(initialPrevHref);
+        var prevData = buildDataUrl(initialPrevHref);
+        if (prevData) initialExtras.push(prevData);
+      }
+      if (initialNextHref) {
+        initialExtras.push(initialNextHref);
+        var nextData = buildDataUrl(initialNextHref);
+        if (nextData) initialExtras.push(nextData);
+      }
+      if (initialExtras.length) {
+        prefetchNavTargets({ extraHrefs: initialExtras });
+      } else {
+        prefetchNavTargets();
+      }
+    })();
     {% endif %}
 
     // ---------------- Conversation helpers ----------------

--- a/templates/partials/lesson_body.html
+++ b/templates/partials/lesson_body.html
@@ -1,0 +1,60 @@
+{# ------------------------ NORMAL LESSON BODY ------------------------ #}
+{% set c = lesson.content or {} %}
+
+{% if (lesson.kind or '') == 'video' %}
+  {% if c.url %}
+    <div class="video-frame"><video controls preload="metadata" src="{{ c.url }}"></video></div>
+  {% else %}
+    <div class="alert">No video URL provided.</div>
+  {% endif %}
+  {% if c.notes_md %}<div class="prose">{{ c.notes_md | rich }}</div>{% endif %}
+
+{% elif (lesson.kind or '') == 'article' %}
+  {% if c.body_md %}
+    <div class="prose">{{ c.body_md | rich }}</div>
+  {% else %}
+    <p class="muted">No article content.</p>
+  {% endif %}
+
+{% elif (lesson.kind or '') == 'quiz' %}
+  {% set qs = c.questions or [] %}
+  {% if qs|length == 0 %}
+    <p class="muted">No quiz questions yet.</p>
+  {% else %}
+    <div class="card quiz-wrap">
+      <h3 style="margin-top:0">Quiz</h3>
+      {% for q in qs %}
+        {% set q_index = loop.index0 %}
+        {% set qtype = q.qtype or 'single_choice' %}
+        <fieldset>
+          <legend>Q{{ loop.index }}.</legend>
+          <div class="prose" style="margin-bottom:6px">{{ q.prompt_md | rich }}</div>
+          {% if (qtype == 'single_choice') or (qtype == 'multiple_choice') %}
+            {% set input_type = 'radio' if qtype == 'single_choice' else 'checkbox' %}
+            {% set group_name = 'q' ~ q_index %}
+            {% for opt in q.options or [] %}
+              {% set opt_id = 'q' ~ q_index ~ '_opt' ~ loop.index0 %}
+              <label class="choice" for="{{ opt_id }}">
+                <input id="{{ opt_id }}" type="{{ input_type }}" name="{{ group_name }}{% if input_type == 'checkbox' %}[]{% endif %}" />
+                <span class="opt-index">{{ 'ABCD'[:4][loop.index0] if loop.index0 < 4 else loop.index }}</span>
+                <span class="prose" style="display:inline-block">{{ opt.text_md | rich }}</span>
+              </label>
+            {% endfor %}
+          {% else %}
+            <textarea rows="4" style="width:100%" placeholder="Type your answer…"></textarea>
+          {% endif %}
+        </fieldset>
+      {% endfor %}
+      <div class="quiz-note">* This quiz is for practice. Client-side scoring can be added later.</div>
+    </div>
+  {% endif %}
+
+{% elif (lesson.kind or '') == 'assignment' %}
+  <div class="prose">{{ (c.instructions_md or '<p>Assignment details TBA</p>') | rich }}</div>
+  {% if c.resource_url %}
+    <p><a class="btn ghost" href="{{ c.resource_url }}" target="_blank" rel="noopener">Open Resource</a></p>
+  {% endif %}
+
+{% else %}
+  <pre><code>{{ (lesson.content or {}) | tojson(indent=2) }}</code></pre>
+{% endif %}


### PR DESCRIPTION
## Summary
- add cached helpers for sidebar metadata and per-lesson lookups in the course content loader
- refactor lesson routing to share a context builder and expose a lightweight JSON endpoint
- update the learn page to render lesson bodies from a partial and fetch lesson content via AJAX

## Testing
- python -m compileall course.py main.py learn.py

------
https://chatgpt.com/codex/tasks/task_e_68e50d6db27c83319b9fea4d1ec8cbb1